### PR TITLE
Refactor internal state management, adds new methods

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -84,9 +84,9 @@ ConstructorInitializerAllOnOneLineOrOnePerLine: true
 # IfMacros:
 #   - KJ_IF_MAYBE
 # IncludeBlocks:   Preserve
-IndentBraces: true
-IndentClasses: true
-IndentNamespaces: true
+#IndentBraces: true
+#IndentClasses: true
+#IndentNamespaces: true
 IncludeCategories:
   - Regex:           '".*"'
     Priority:        1

--- a/demo/examples/abilities_states/abilities/abilities_states_test_ability.gd
+++ b/demo/examples/abilities_states/abilities/abilities_states_test_ability.gd
@@ -9,7 +9,3 @@ func _init(_ability_name = ABILITY_NAME) -> void:
 
 func _get_cooldown(ability_container: AbilityContainer) -> float:
 	return ability_container.get_parent().ability_cooldown
-
-
-func _should_be_blocked(ability_container: AbilityContainer) -> bool:
-	return ability_container.get_parent().should_be_blocked

--- a/demo/examples/abilities_states/abilities/abilities_states_test_ability.gd
+++ b/demo/examples/abilities_states/abilities/abilities_states_test_ability.gd
@@ -9,3 +9,7 @@ func _init(_ability_name = ABILITY_NAME) -> void:
 
 func _get_cooldown(ability_container: AbilityContainer) -> float:
 	return ability_container.get_parent().ability_cooldown
+
+
+func _should_be_blocked(ability_container: AbilityContainer) -> bool:
+	return ability_container.get_parent().should_be_blocked

--- a/demo/examples/abilities_states/abilities/abilities_states_test_ability.gd
+++ b/demo/examples/abilities_states/abilities/abilities_states_test_ability.gd
@@ -3,9 +3,14 @@ extends Ability
 
 const ABILITY_NAME := "AbilitiesStatesTestAbility"
 
+
 func _init(_ability_name = ABILITY_NAME) -> void:
 	ability_name = _ability_name
 
 
 func _get_cooldown(ability_container: AbilityContainer) -> float:
-	return ability_container.get_parent().ability_cooldown
+	return ability_container.get_parent().ability_cooldown_spin_box.value
+
+
+func _get_duration(ability_container: AbilityContainer) -> float:
+	return ability_container.get_parent().duration_spin_box.value

--- a/demo/examples/abilities_states/abilities/abilities_states_test_ability.gd
+++ b/demo/examples/abilities_states/abilities/abilities_states_test_ability.gd
@@ -5,3 +5,7 @@ const ABILITY_NAME := "AbilitiesStatesTestAbility"
 
 func _init(_ability_name = ABILITY_NAME) -> void:
 	ability_name = _ability_name
+
+
+func _get_cooldown(ability_container: AbilityContainer) -> float:
+	return ability_container.get_parent().ability_cooldown

--- a/demo/examples/abilities_states/abilities_states.gd
+++ b/demo/examples/abilities_states/abilities_states.gd
@@ -1,1 +1,41 @@
 extends VBoxContainer
+
+
+@onready var ability_container: AbilityContainer = %AbilityContainer
+@onready var ability_cooldown_spin_box: SpinBox = $HBoxContainer/AbilityCooldownSpinBox
+@onready var activate_button: Button = %ActivateButton
+@onready var grant_button: Button = %GrantButton
+
+
+@export var ability_cooldown 	:= 0.0:
+	get:
+		return ability_cooldown_spin_box.value
+	set(value):
+		if value != null:
+			ability_cooldown_spin_box.value = value
+
+
+func _ready() -> void:
+	ability_cooldown_spin_box.value = ability_cooldown
+	
+	activate_button.pressed.connect(func ():
+		var ability: RuntimeAbility = get_ability()
+		
+		if ability.is_active():
+			ability_container.try_end(ability.get_ability())
+		else:
+			ability_container.try_activate(ability.get_ability())
+	)
+
+	grant_button.pressed.connect(func ():
+		var ability: RuntimeAbility = get_ability()
+
+		if ability.is_granted():
+			ability_container.try_revoke(ability.get_ability())
+		else:
+			ability_container.try_grant(ability.get_ability())
+	)
+
+
+func get_ability() -> RuntimeAbility:
+	return ability_container.get_ability(AbilitiesStatesTestAbility.ABILITY_NAME)

--- a/demo/examples/abilities_states/abilities_states.gd
+++ b/demo/examples/abilities_states/abilities_states.gd
@@ -2,23 +2,19 @@ extends VBoxContainer
 
 
 @onready var ability_container: AbilityContainer = %AbilityContainer
-@onready var ability_cooldown_spin_box: SpinBox = $HBoxContainer/AbilityCooldownSpinBox
 @onready var activate_button: Button = %ActivateButton
 @onready var block_button: Button = %BlockButton
 @onready var grant_button: Button = %GrantButton
+@onready var ability_cooldown_spin_box: SpinBox = %AbilityCooldownSpinBox
+@onready var duration_spin_box: SpinBox = %DurationSpinBox
 
 @onready var activated_ability_state_h_box_container: HBoxContainer = %ActivatedAbilityStateHBoxContainer
 @onready var blocked_ability_state_h_box_container: HBoxContainer = %BlockedAbilityStateHBoxContainer
 @onready var granted_ability_state_h_box_container: HBoxContainer = %GrantedAbilityStateHBoxContainer
 @onready var cooldown_ability_state_h_box_container: HBoxContainer = %CooldownAbilityStateHBoxContainer
-
-
-@export var ability_cooldown 	:= 0.0:
-	get:
-		return ability_cooldown_spin_box.value
-	set(value):
-		if value != null:
-			ability_cooldown_spin_box.value = value
+@onready var end_button: Button = %EndButton
+@onready var unblock_button: Button = %UnblockButton
+@onready var revoke_button: Button = %RevokeButton
 
 
 func _ready() -> void:
@@ -31,40 +27,20 @@ func _ready() -> void:
 	ability_container.cooldown_end.connect(handle_state_changed("cooldown_end"))
 	ability_container.cooldown_start.connect(handle_state_changed("cooldown_start"))
 	
-	ability_cooldown_spin_box.value = ability_cooldown
+	ability_cooldown_spin_box.value = 0.0
 	
-	handle_state_changed().call(get_ability().get_ability())
+	handle_state_changed().call(get_ability())
 	
-	activate_button.pressed.connect(func ():
-		var ability: RuntimeAbility = get_ability()
-		
-		if ability.is_active():
-			ability_container.try_end(ability.get_ability())
-		else:
-			ability_container.try_activate(ability.get_ability())
-	)
-	
-	block_button.pressed.connect(func ():
-		var ability: RuntimeAbility = get_ability()
-
-		if ability.is_blocked():
-			ability_container.try_unblock(ability.get_ability())
-		else:
-			ability_container.try_block(ability.get_ability())
-	)
-
-	grant_button.pressed.connect(func ():
-		var ability: RuntimeAbility = get_ability()
-
-		if ability.is_granted():
-			ability_container.try_revoke(ability.get_ability())
-		else:
-			ability_container.try_grant(ability.get_ability())
-	)
+	activate_button.pressed.connect(ability_container.try_activate.bind(get_ability()))
+	block_button.pressed.connect(ability_container.try_block.bind(get_ability()))
+	grant_button.pressed.connect(ability_container.try_grant.bind(get_ability()))
+	end_button.pressed.connect(ability_container.try_end.bind(get_ability()))
+	unblock_button.pressed.connect(ability_container.try_unblock.bind(get_ability()))
+	revoke_button.pressed.connect(ability_container.try_revoke.bind(get_ability()))
 
 
-func get_ability() -> RuntimeAbility:
-	return ability_container.get_ability(AbilitiesStatesTestAbility.ABILITY_NAME)
+func get_ability() -> Ability:
+	return ability_container.get_runtime_ability(AbilitiesStatesTestAbility.ABILITY_NAME).get_ability()
 	
 	
 func handle_state_changed(signal_name: String = "") -> Callable:
@@ -85,21 +61,6 @@ ability_container.is_ability_cooldown_active(ability)	:{4}
 				4: ability_container.is_ability_cooldown_active(ability),
 			})
 			)
-		
-		if ability_container.is_ability_active(ability):
-			activate_button.text = "End ability"
-		else:
-			activate_button.text = "Activate ability"
-			
-		if ability_container.is_ability_blocked(ability):
-			block_button.text = "Unblock ability"
-		else:
-			block_button.text = "Block ability"
-			
-		if ability_container.is_ability_granted(ability):
-			grant_button.text = "Revoke ability"
-		else:
-			grant_button.text = "Grant ability"
 			
 		activated_ability_state_h_box_container.value 	= ability_container.is_ability_active(ability)
 		blocked_ability_state_h_box_container.value 	= ability_container.is_ability_blocked(ability)

--- a/demo/examples/abilities_states/abilities_states.gd
+++ b/demo/examples/abilities_states/abilities_states.gd
@@ -39,34 +39,27 @@ func _ready() -> void:
 		var ability: RuntimeAbility = get_ability()
 		
 		if ability.is_active():
-			if ability_container.try_end(ability.get_ability()) == RuntimeAbility.ABILITY_EVENT_TYPE_ENDED:
-				activate_button.text = "Activate ability"
+			ability_container.try_end(ability.get_ability())
 		else:
-			if ability_container.try_activate(ability.get_ability()) == RuntimeAbility.ABILITY_EVENT_TYPE_ACTIVATED:
-				activate_button.text = "End ability"
+			ability_container.try_activate(ability.get_ability())
 	)
 	
 	block_button.pressed.connect(func ():
 		var ability: RuntimeAbility = get_ability()
 
 		if ability.is_blocked():
-			if ability_container.try_unblock(ability.get_ability()) == RuntimeAbility.ABILITY_EVENT_TYPE_UNBLOCKED:
-				block_button.text = "Block ability"
+			ability_container.try_unblock(ability.get_ability())
 		else:
 			ability_container.try_block(ability.get_ability())
-			if ability_container.try_block(ability.get_ability()) == RuntimeAbility.ABILITY_EVENT_TYPE_BLOCKED:
-				block_button.text = "Unblock ability"
 	)
 
 	grant_button.pressed.connect(func ():
 		var ability: RuntimeAbility = get_ability()
 
 		if ability.is_granted():
-			if ability_container.try_revoke(ability.get_ability()) == RuntimeAbility.ABILITY_EVENT_TYPE_REVOKED:
-				grant_button.text = "Grant ability"
+			ability_container.try_revoke(ability.get_ability())
 		else:
-			if ability_container.try_grant(ability.get_ability()) == RuntimeAbility.ABILITY_EVENT_TYPE_GRANTED:
-				grant_button.text = "Revoke ability"
+			ability_container.try_grant(ability.get_ability())
 	)
 
 
@@ -93,6 +86,21 @@ ability_container.is_ability_cooldown_active(ability)	:{4}
 			})
 			)
 		
+		if ability_container.is_ability_active(ability):
+			activate_button.text = "End ability"
+		else:
+			activate_button.text = "Activate ability"
+			
+		if ability_container.is_ability_blocked(ability):
+			block_button.text = "Unblock ability"
+		else:
+			block_button.text = "Block ability"
+			
+		if ability_container.is_ability_granted(ability):
+			grant_button.text = "Revoke ability"
+		else:
+			grant_button.text = "Grant ability"
+			
 		activated_ability_state_h_box_container.value 	= ability_container.is_ability_active(ability)
 		blocked_ability_state_h_box_container.value 	= ability_container.is_ability_blocked(ability)
 		granted_ability_state_h_box_container.value 	= ability_container.is_ability_granted(ability)

--- a/demo/examples/abilities_states/abilities_states.gd
+++ b/demo/examples/abilities_states/abilities_states.gd
@@ -4,6 +4,7 @@ extends VBoxContainer
 @onready var ability_container: AbilityContainer = %AbilityContainer
 @onready var ability_cooldown_spin_box: SpinBox = $HBoxContainer/AbilityCooldownSpinBox
 @onready var activate_button: Button = %ActivateButton
+@onready var block_button: Button = %BlockButton
 @onready var grant_button: Button = %GrantButton
 
 
@@ -15,6 +16,9 @@ extends VBoxContainer
 			ability_cooldown_spin_box.value = value
 
 
+var should_be_blocked := false
+
+
 func _ready() -> void:
 	ability_cooldown_spin_box.value = ability_cooldown
 	
@@ -22,18 +26,36 @@ func _ready() -> void:
 		var ability: RuntimeAbility = get_ability()
 		
 		if ability.is_active():
-			ability_container.try_end(ability.get_ability())
+			if ability_container.try_end(ability.get_ability()) == RuntimeAbility.ABILITY_EVENT_TYPE_ENDED:
+				activate_button.text = "Activate ability"
 		else:
-			ability_container.try_activate(ability.get_ability())
+			if ability_container.try_activate(ability.get_ability()) == RuntimeAbility.ABILITY_EVENT_TYPE_ACTIVATED:
+				activate_button.text = "End ability"
+	)
+	
+	block_button.pressed.connect(func ():
+		var ability: RuntimeAbility = get_ability()
+		
+		should_be_blocked = !should_be_blocked
+		
+		if ability.is_blocked():
+			should_be_blocked = false
+			block_button.text = "Block ability"
+		else:
+			should_be_blocked = true
+			if ability_container.try_block(ability.get_ability()) == RuntimeAbility.ABILITY_EVENT_TYPE_BLOCKED:
+				block_button.text = "Unblock ability"
 	)
 
 	grant_button.pressed.connect(func ():
 		var ability: RuntimeAbility = get_ability()
 
 		if ability.is_granted():
-			ability_container.try_revoke(ability.get_ability())
+			if ability_container.try_revoke(ability.get_ability()) == RuntimeAbility.ABILITY_EVENT_TYPE_REVOKED:
+				grant_button.text = "Grant ability"
 		else:
-			ability_container.try_grant(ability.get_ability())
+			if ability_container.try_grant(ability.get_ability()) == RuntimeAbility.ABILITY_EVENT_TYPE_GRANTED:
+				grant_button.text = "Revoke ability"
 	)
 
 

--- a/demo/examples/abilities_states/abilities_states.tscn
+++ b/demo/examples/abilities_states/abilities_states.tscn
@@ -58,12 +58,17 @@ alignment = 1
 [node name="ActivateButton" type="Button" parent="HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-text = "Activate/Cancel"
+text = "Activate ability"
+
+[node name="BlockButton" type="Button" parent="HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Block ability"
 
 [node name="GrantButton" type="Button" parent="HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-text = "Grant/Revoke"
+text = "Revoke ability"
 
 [node name="AbilityCooldownSpinBox" type="SpinBox" parent="HBoxContainer"]
 layout_mode = 2

--- a/demo/examples/abilities_states/abilities_states.tscn
+++ b/demo/examples/abilities_states/abilities_states.tscn
@@ -16,30 +16,54 @@ anchor_right = 0.5
 anchor_bottom = 0.5
 grow_horizontal = 2
 grow_vertical = 2
+theme_override_constants/separation = 16
+alignment = 1
 script = ExtResource("1_705gc")
+
+[node name="AbilityContainer" type="AbilityContainer" parent="."]
+abilities = Array[Ability]([SubResource("Ability_gi80w")])
+unique_name_in_owner = true
 
 [node name="Ability States" type="Label" parent="."]
 layout_mode = 2
 text = "Ability States"
 
-[node name="AbilityStateHBoxContainer" parent="." node_paths=PackedStringArray("ability_container") instance=ExtResource("2_gi80w")]
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 2
-ability_container = NodePath("../AbilityContainer")
+theme_override_constants/separation = 8
 
-[node name="AbilityStateHBoxContainer2" parent="." node_paths=PackedStringArray("ability_container") instance=ExtResource("2_gi80w")]
+[node name="AbilityStateHBoxContainer" parent="VBoxContainer" node_paths=PackedStringArray("ability_container") instance=ExtResource("2_gi80w")]
 layout_mode = 2
-ability_container = NodePath("../AbilityContainer")
+ability_container = NodePath("../../AbilityContainer")
+
+[node name="AbilityStateHBoxContainer2" parent="VBoxContainer" node_paths=PackedStringArray("ability_container") instance=ExtResource("2_gi80w")]
+layout_mode = 2
+ability_container = NodePath("../../AbilityContainer")
 state_to_display = 1
 
-[node name="AbilityStateHBoxContainer3" parent="." node_paths=PackedStringArray("ability_container") instance=ExtResource("2_gi80w")]
+[node name="AbilityStateHBoxContainer3" parent="VBoxContainer" node_paths=PackedStringArray("ability_container") instance=ExtResource("2_gi80w")]
 layout_mode = 2
-ability_container = NodePath("../AbilityContainer")
+ability_container = NodePath("../../AbilityContainer")
 state_to_display = 2
 
-[node name="AbilityStateHBoxContainer4" parent="." node_paths=PackedStringArray("ability_container") instance=ExtResource("2_gi80w")]
+[node name="AbilityStateHBoxContainer4" parent="VBoxContainer" node_paths=PackedStringArray("ability_container") instance=ExtResource("2_gi80w")]
 layout_mode = 2
-ability_container = NodePath("../AbilityContainer")
+ability_container = NodePath("../../AbilityContainer")
 state_to_display = 3
 
-[node name="AbilityContainer" type="AbilityContainer" parent="."]
-abilities = Array[Ability]([SubResource("Ability_gi80w")])
+[node name="HBoxContainer" type="HBoxContainer" parent="."]
+layout_mode = 2
+alignment = 1
+
+[node name="ActivateButton" type="Button" parent="HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Activate/Cancel"
+
+[node name="GrantButton" type="Button" parent="HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Grant/Revoke"
+
+[node name="AbilityCooldownSpinBox" type="SpinBox" parent="HBoxContainer"]
+layout_mode = 2

--- a/demo/examples/abilities_states/abilities_states.tscn
+++ b/demo/examples/abilities_states/abilities_states.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=5 format=3 uid="uid://ds6exarfjv6q7"]
 
-[ext_resource type="Script" uid="uid://dfa0x18sdyu6o" path="res://examples/abilities_states/abilities_states.gd" id="1_705gc"]
-[ext_resource type="Script" uid="uid://dpc8pqdvlooj0" path="res://examples/abilities_states/abilities/abilities_states_test_ability.gd" id="2_2p100"]
+[ext_resource type="Script" uid="uid://ckp13ffbue64x" path="res://examples/abilities_states/abilities_states.gd" id="1_705gc"]
+[ext_resource type="Script" uid="uid://t5kk40w2pd7x" path="res://examples/abilities_states/abilities/abilities_states_test_ability.gd" id="2_2p100"]
 [ext_resource type="PackedScene" uid="uid://celbrugx55ha8" path="res://examples/abilities_states/ability_state_h_box_container.tscn" id="2_gi80w"]
 
 [sub_resource type="Ability" id="Ability_gi80w"]
@@ -58,17 +58,65 @@ alignment = 1
 [node name="ActivateButton" type="Button" parent="HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
+size_flags_horizontal = 3
 text = "Activate ability"
 
 [node name="BlockButton" type="Button" parent="HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
+size_flags_horizontal = 3
 text = "Block ability"
 
 [node name="GrantButton" type="Button" parent="HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
+size_flags_horizontal = 3
+text = "Grant ability"
+
+[node name="HBoxContainer2" type="HBoxContainer" parent="."]
+layout_mode = 2
+alignment = 1
+
+[node name="EndButton" type="Button" parent="HBoxContainer2"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+text = "End ability"
+
+[node name="UnblockButton" type="Button" parent="HBoxContainer2"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Unblock ability"
+
+[node name="RevokeButton" type="Button" parent="HBoxContainer2"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
 text = "Revoke ability"
 
-[node name="AbilityCooldownSpinBox" type="SpinBox" parent="HBoxContainer"]
+[node name="HBoxContainer3" type="HBoxContainer" parent="."]
+layout_mode = 2
+theme_override_constants/separation = 32
+
+[node name="VBoxContainer" type="VBoxContainer" parent="HBoxContainer3"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="HBoxContainer3/VBoxContainer"]
+layout_mode = 2
+text = "Cooldown (in seconds)"
+
+[node name="AbilityCooldownSpinBox" type="SpinBox" parent="HBoxContainer3/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="VBoxContainer2" type="VBoxContainer" parent="HBoxContainer3"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="HBoxContainer3/VBoxContainer2"]
+layout_mode = 2
+text = "Duration (in seconds)"
+
+[node name="DurationSpinBox" type="SpinBox" parent="HBoxContainer3/VBoxContainer2"]
+unique_name_in_owner = true
 layout_mode = 2

--- a/demo/examples/abilities_states/abilities_states.tscn
+++ b/demo/examples/abilities_states/abilities_states.tscn
@@ -32,23 +32,23 @@ text = "Ability States"
 layout_mode = 2
 theme_override_constants/separation = 8
 
-[node name="AbilityStateHBoxContainer" parent="VBoxContainer" node_paths=PackedStringArray("ability_container") instance=ExtResource("2_gi80w")]
+[node name="ActivatedAbilityStateHBoxContainer" parent="VBoxContainer" instance=ExtResource("2_gi80w")]
+unique_name_in_owner = true
 layout_mode = 2
-ability_container = NodePath("../../AbilityContainer")
 
-[node name="AbilityStateHBoxContainer2" parent="VBoxContainer" node_paths=PackedStringArray("ability_container") instance=ExtResource("2_gi80w")]
+[node name="BlockedAbilityStateHBoxContainer" parent="VBoxContainer" instance=ExtResource("2_gi80w")]
+unique_name_in_owner = true
 layout_mode = 2
-ability_container = NodePath("../../AbilityContainer")
 state_to_display = 1
 
-[node name="AbilityStateHBoxContainer3" parent="VBoxContainer" node_paths=PackedStringArray("ability_container") instance=ExtResource("2_gi80w")]
+[node name="GrantedAbilityStateHBoxContainer" parent="VBoxContainer" instance=ExtResource("2_gi80w")]
+unique_name_in_owner = true
 layout_mode = 2
-ability_container = NodePath("../../AbilityContainer")
 state_to_display = 2
 
-[node name="AbilityStateHBoxContainer4" parent="VBoxContainer" node_paths=PackedStringArray("ability_container") instance=ExtResource("2_gi80w")]
+[node name="CooldownAbilityStateHBoxContainer" parent="VBoxContainer" instance=ExtResource("2_gi80w")]
+unique_name_in_owner = true
 layout_mode = 2
-ability_container = NodePath("../../AbilityContainer")
 state_to_display = 3
 
 [node name="HBoxContainer" type="HBoxContainer" parent="."]

--- a/demo/examples/abilities_states/ability_state_h_box_container.gd
+++ b/demo/examples/abilities_states/ability_state_h_box_container.gd
@@ -10,8 +10,15 @@ enum States {
 }
 
 
-@export var ability_container: AbilityContainer = null
-@export_enum("Activated", "Blocked", "Granted", "Cooling down") var state_to_display: int = States.ACTIVATED
+@export_enum("Activated", "Blocked", "Granted", "Cooling down") var state_to_display: int 	= States.ACTIVATED
+@export var value																			:= false:
+	get:
+		return state_state_label.text == "✅"
+	set(value):
+		if value:
+			state_state_label.text = "✅"
+		else:
+			state_state_label.text = "❌"
 
 
 @onready var state_name_label: Label = %StateNameLabel
@@ -28,30 +35,4 @@ func _get_state_label(state: int) -> String:
 
 
 func _ready() -> void:
-	if ability_container:
-		ability_container.ability_activated.connect(make_handler(state_to_display))
-		ability_container.ability_blocked.connect(make_handler(state_to_display))
-		ability_container.ability_granted.connect(make_handler(state_to_display))
-		ability_container.ability_revoked.connect(make_handler(state_to_display))
-		ability_container.ability_ended.connect(make_handler(state_to_display))
-		
-		make_handler(state_to_display).call(ability_container.get_ability(AbilitiesStatesTestAbility.ABILITY_NAME).get_ability())
-
-
-func _set_state_value(state_name: String, state_value: bool) -> void:
-	state_name_label.text = state_name
-	if state_value:
-		state_state_label.text = "✅"
-	else:
-		state_state_label.text = "❌"
-
-
-func make_handler(state: int) -> Callable:
-	return func handler(ability: Ability) -> void:
-		var runtime_ability = ability_container.get_ability(ability)
-
-		match state:
-			States.ACTIVATED: _set_state_value(_get_state_label(state), runtime_ability.is_active()) 
-			States.BLOCKED: _set_state_value(_get_state_label(state), runtime_ability.is_blocked()) 
-			States.GRANTED: _set_state_value(_get_state_label(state), runtime_ability.is_granted()) 
-			States.COOLING_DOWN: _set_state_value(_get_state_label(state), runtime_ability.is_cooldown_active()) 
+	state_name_label.text = _get_state_label(state_to_display)

--- a/demo/examples/abilities_states/ability_state_h_box_container.gd
+++ b/demo/examples/abilities_states/ability_state_h_box_container.gd
@@ -34,7 +34,8 @@ func _ready() -> void:
 		ability_container.ability_granted.connect(make_handler(state_to_display))
 		ability_container.ability_revoked.connect(make_handler(state_to_display))
 		ability_container.ability_ended.connect(make_handler(state_to_display))
-		_set_state_value(_get_state_label(state_to_display), false)
+		
+		make_handler(state_to_display).call(ability_container.get_ability(AbilitiesStatesTestAbility.ABILITY_NAME).get_ability())
 
 
 func _set_state_value(state_name: String, state_value: bool) -> void:

--- a/demo/examples/abilities_states/ability_state_h_box_container.gd
+++ b/demo/examples/abilities_states/ability_state_h_box_container.gd
@@ -28,12 +28,13 @@ func _get_state_label(state: int) -> String:
 
 
 func _ready() -> void:
-	ability_container.ability_activated.connect(make_handler(state_to_display))
-	ability_container.ability_blocked.connect(make_handler(state_to_display))
-	ability_container.ability_granted.connect(make_handler(state_to_display))
-	ability_container.ability_revoked.connect(make_handler(state_to_display))
-	ability_container.ability_ended.connect(make_handler(state_to_display))
-	_set_state_value(_get_state_label(state_to_display), false)
+	if ability_container:
+		ability_container.ability_activated.connect(make_handler(state_to_display))
+		ability_container.ability_blocked.connect(make_handler(state_to_display))
+		ability_container.ability_granted.connect(make_handler(state_to_display))
+		ability_container.ability_revoked.connect(make_handler(state_to_display))
+		ability_container.ability_ended.connect(make_handler(state_to_display))
+		_set_state_value(_get_state_label(state_to_display), false)
 
 
 func _set_state_value(state_name: String, state_value: bool) -> void:

--- a/demo/main.tscn
+++ b/demo/main.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=4 format=3 uid="uid://6my7uk0ymjke"]
 
-[ext_resource type="Script" uid="uid://cf47te3a3f74h" path="res://main.gd" id="1_ig7tw"]
+[ext_resource type="Script" uid="uid://dvrakog0hb8by" path="res://main.gd" id="1_ig7tw"]
 [ext_resource type="PackedScene" uid="uid://da22ctof8levq" path="res://examples/naval_battles/naval_battles.tscn" id="2_0xm2m"]
 [ext_resource type="PackedScene" uid="uid://ds6exarfjv6q7" path="res://examples/abilities_states/abilities_states.tscn" id="3_h2yge"]
 

--- a/src/ability_system.cpp
+++ b/src/ability_system.cpp
@@ -347,8 +347,9 @@ AbilityContainer *RuntimeAbility::get_container() const
 double RuntimeAbility::get_cooldown() const
 {
 	if (GDVIRTUAL_IS_OVERRIDDEN_PTR(ability, _get_cooldown)) {
-		double cooldown = 0.0;
-		GDVIRTUAL_CALL_PTR(ability, _get_cooldown, container, cooldown);
+		if (double cooldown = 0.0; GDVIRTUAL_CALL_PTR(ability, _get_cooldown, container, cooldown)) {
+			return cooldown;
+		}
 	}
 
 	return 0.0;
@@ -357,8 +358,9 @@ double RuntimeAbility::get_cooldown() const
 double RuntimeAbility::get_duration() const
 {
 	if (GDVIRTUAL_IS_OVERRIDDEN_PTR(ability, _get_duration)) {
-		double duration = 0.0;
-		GDVIRTUAL_CALL_PTR(ability, _get_duration, container, duration);
+		if (double duration = 0.0; GDVIRTUAL_CALL_PTR(ability, _get_duration, container, duration)) {
+			return duration;
+		}
 	}
 
 	return 0.0;

--- a/src/ability_system.cpp
+++ b/src/ability_system.cpp
@@ -125,9 +125,11 @@ void RuntimeAbility::_bind_methods()
 	ClassDB::bind_method(D_METHOD("is_duration_active"), &RuntimeAbility::is_duration_active);
 	ClassDB::bind_method(D_METHOD("is_ended"), &RuntimeAbility::is_ended);
 	ClassDB::bind_method(D_METHOD("is_granted"), &RuntimeAbility::is_granted);
+	ClassDB::bind_method(D_METHOD("is_revoked"), &RuntimeAbility::is_revoked);
 	ClassDB::bind_method(D_METHOD("revoke"), &RuntimeAbility::revoke);
 	ClassDB::bind_method(D_METHOD("set_ability", "ability"), &RuntimeAbility::set_ability);
 	ClassDB::bind_method(D_METHOD("set_container", "container"), &RuntimeAbility::set_container);
+	ClassDB::bind_method(D_METHOD("unblock"), &RuntimeAbility::unblock);
 
 	/// binds enum constants to godot
 	BIND_ENUM_CONSTANT(ABILITY_EVENT_TYPE_ACTIVATED);

--- a/src/ability_system.hpp
+++ b/src/ability_system.hpp
@@ -19,7 +19,7 @@ namespace octod::gameplay::abilities
 	enum AbilityState : unsigned int
 	{
 		/// @brief Represents the ability being in no state.
-		ABILITY_STATE_NONE = 1 << 0,
+		ABILITY_STATE_IDLE = 1 << 0,
 		/// @brief Represents the ability being active.
 		ABILITY_STATE_ACTIVE = 1 << 1,
 		/// @brief Represents the ability being blocked.
@@ -118,7 +118,7 @@ namespace octod::gameplay::abilities
 		GDCLASS(RuntimeAbility, RefCounted);
 
 		/// @brief Marks the ability state. Using a bitmask to store the state.
-		int state = ABILITY_STATE_NONE;
+		int state = ABILITY_STATE_IDLE;
 
 	public:
 		/// @brief Activates the ability.
@@ -207,6 +207,12 @@ namespace octod::gameplay::abilities
 
 		/// @brief Triggers the ability duration.
 		bool trigger_duration();
+
+		/// @brief Tries to reset the ability cooldown.
+		void try_reset_cooldown();
+
+		/// @brief Tries to reset the ability duration.
+		void try_reset_duration();
 	};
 
 #pragma endregion
@@ -402,9 +408,9 @@ namespace octod::gameplay::abilities
 		/// @brief Called when the ability container checks if the ability should be granted.
 		GDVIRTUAL1RC(bool, _should_be_ended, AbilityContainer *);
 		/// @brief Called when the ability container checks if the ability cooldown should be reset when blocked.
-		GDVIRTUAL1RC(bool, _should_reset_cooldown_on_block, AbilityContainer *);
+		GDVIRTUAL1RC(bool, _should_reset_cooldown, AbilityContainer *);
 		/// @brief Called when the ability container checks if the ability duration should be reset when blocked.
-		GDVIRTUAL1RC(bool, _should_reset_duration_on_block, AbilityContainer *);
+		GDVIRTUAL1RC(bool, _should_reset_duration, AbilityContainer *);
 
 		/// @brief Gets the ability name.
 		/// @return The ability name.

--- a/src/ability_system.hpp
+++ b/src/ability_system.hpp
@@ -18,53 +18,95 @@ namespace octod::gameplay::abilities
 	/// @brief Let's have fun with bitmasks to handle the ability internal state.
 	enum AbilityState : unsigned int
 	{
-		ABILITY_STATE_NONE,
-		ABILITY_STATE_ACTIVE,
-		ABILITY_STATE_BLOCKED,
-		ABILITY_STATE_GRANTED,
+		/// @brief Represents the ability being in no state.
+		ABILITY_STATE_NONE = 1 << 0,
+		/// @brief Represents the ability being active.
+		ABILITY_STATE_ACTIVE = 1 << 1,
+		/// @brief Represents the ability being blocked.
+		ABILITY_STATE_BLOCKED = 1 << 2,
+		/// @brief Represents the ability being granted.
+		ABILITY_STATE_GRANTED = 1 << 3,
 	};
 
 	enum AbilityEventType : unsigned int
 	{
 		/// success events
+		/// @brief Represents the ability being activated.
 		ABILITY_EVENT_TYPE_ACTIVATED,
+		/// @brief Represents the ability being blocked.
 		ABILITY_EVENT_TYPE_BLOCKED,
+		/// @brief Represents the ability being ended.
 		ABILITY_EVENT_TYPE_ENDED,
+		/// @brief Represents the ability being granted.
 		ABILITY_EVENT_TYPE_GRANTED,
+		/// @brief Represents the ability being revoked.
 		ABILITY_EVENT_TYPE_REVOKED,
+		/// @brief Represents the ability being unblocked.
+		ABILITY_EVENT_TYPE_UNBLOCKED,
 
 		/// refusal events
+		/// @brief Represents the ability being refused to activate.
 		ABILITY_EVENT_TYPE_REFUSED_TO_ACTIVATE,
+		/// @brief Represents the ability being refused to activate because the ability itself decided to block itself.
 		ABILITY_EVENT_TYPE_REFUSED_TO_ACTIVATE_DECIDED_TO_BLOCK,
+		/// @brief Represents the ability being refused to activate because it is blocked.
 		ABILITY_EVENT_TYPE_REFUSED_TO_ACTIVATE_IS_BLOCKED,
+		/// @brief Represents the ability being refused to activate because it is cooling down.
 		ABILITY_EVENT_TYPE_REFUSED_TO_ACTIVATE_IS_COOLING_DOWN,
+		/// @brief Represents the ability being refused to activate because the duration is active.
 		ABILITY_EVENT_TYPE_REFUSED_TO_ACTIVATE_IS_DURATION_ACTIVE,
+		/// @brief Represents the ability being refused to activate because it is revoked.
 		ABILITY_EVENT_TYPE_REFUSED_TO_ACTIVATE_IS_REVOKED,
 
+		/// @brief Represents the ability being refused to block.
 		ABILITY_EVENT_TYPE_REFUSED_TO_BLOCK,
-		ABILITY_EVENT_TYPE_REFUSED_TO_BLOCK_IS_NOT_ACTIVE,
+		/// @brief Represents the ability being refused to block because it is not granted.
 		ABILITY_EVENT_TYPE_REFUSED_TO_BLOCK_IS_NOT_GRANTED,
 
+		/// @brief Represents the ability being refused to end.
 		ABILITY_EVENT_TYPE_REFUSED_TO_END,
+		/// @brief Represents the ability being refused to end because it is blocked.
 		ABILITY_EVENT_TYPE_REFUSED_TO_END_IS_BLOCKED,
+		/// @brief Represents the ability being refused to end because it is not active.
 		ABILITY_EVENT_TYPE_REFUSED_TO_END_IS_NOT_ACTIVE,
+		/// @brief Represents the ability being refused to end because it is not granted.
 		ABILITY_EVENT_TYPE_REFUSED_TO_END_IS_NOT_GRANTED,
 
+		/// @brief Represents the ability being refused to grant.
 		ABILITY_EVENT_TYPE_REFUSED_TO_GRANT,
+		/// @brief Represents the ability being refused to grant because it is already granted.
 		ABILITY_EVENT_TYPE_REFUSED_TO_GRANT_ALREADY_GRANTED,
 
+		/// @brief Represents the ability being refused to revoke.
 		ABILITY_EVENT_TYPE_REFUSED_TO_REVOKE,
+		/// @brief Represents the ability being refused to revoke because it is already revoked.
 		ABILITY_EVENT_TYPE_REFUSED_TO_REVOKE_ALREADY_REVOKED,
 
+		/// @brief Represents the ability being refused to unblock.
+		ABILITY_EVENT_TYPE_REFUSED_TO_UNBLOCK,
+		/// @brief Represents the ability being refused to unblock because it is not blocked.
+		ABILITY_EVENT_TYPE_REFUSED_TO_UNBLOCK_IS_NOT_BLOCKED,
+		/// @brief Represents the ability being refused to unblock because it should be blocked.
+		ABILITY_EVENT_TYPE_REFUSED_TO_UNBLOCK_SHOULD_BE_BLOCKED,
+
 		/// error events
+		/// @brief Represents an error activating the ability.
 		ABILITY_EVENT_TYPE_ERROR_ACTIVATING,
+		/// @brief Represents an error blocking the ability.
 		ABILITY_EVENT_TYPE_ERROR_BLOCKING,
+		/// @brief Represents an error ending the ability.
 		ABILITY_EVENT_TYPE_ERROR_ENDING,
+		/// @brief Represents an error granting the ability.
 		ABILITY_EVENT_TYPE_ERROR_GRANTING,
+		/// @brief Represents an error revoking the ability.
 		ABILITY_EVENT_TYPE_ERROR_REVOKING,
+		/// @brief Represents an error unblocking the ability.
+		ABILITY_EVENT_TYPE_ERROR_UNBLOCKING,
 
 		/// more bad errors, these are related to the container itself.
+		/// @brief Returned when the ability container did not find the ability.
 		ABILITY_NOT_FOUND,
+		/// @brief Returned when the ability parameter is null on some method.
 		ABILITY_PARAMETER_IS_NULL
 	};
 
@@ -135,6 +177,8 @@ namespace octod::gameplay::abilities
 		/// @brief Returns true if the ability should be ended.
 		/// @return True if the ability should be ended, false otherwise.
 		[[nodiscard]] bool should_be_ended() const;
+		/// @brief Unblocks the ability.
+		[[nodiscard]] AbilityEventType unblock();
 
 	protected:
 		friend class AbilityContainer;
@@ -175,6 +219,7 @@ namespace octod::gameplay::abilities
 		[[nodiscard]] Ref<RuntimeAbility> build_runtime_ability(const Ref<Ability> &p_ability) const;
 
 		/// @brief Called when the node receives a notification.
+		// ReSharper disable once CppHidingFunction
 		void _notification(int p_what);
 		/// @brief Handles the active ability signal.
 		/// @param p_runtime_ability The runtime ability.
@@ -197,6 +242,9 @@ namespace octod::gameplay::abilities
 		/// @brief Handles the cooldown start signal.
 		/// @param p_runtime_ability The runtime ability.
 		void _on_cooldown_start(const Ref<RuntimeAbility> &p_runtime_ability);
+		/// @brief Handles the ability unblock signal.
+		/// @param p_runtime_ability The runtime ability.
+		void _on_unblocked(const Ref<RuntimeAbility> &p_runtime_ability);
 
 	public:
 		/// @brief Returns an instance of a RuntimeAbility. Override this method if you want to use an extended class of RuntimeAbility.
@@ -213,6 +261,8 @@ namespace octod::gameplay::abilities
 		GDVIRTUAL1RC(int, _try_grant, Variant); // NOLINT(*-unnecessary-value-param)
 		/// @brief The virtual method called to revoke an ability.
 		GDVIRTUAL1RC(int, _try_revoke, Variant); // NOLINT(*-unnecessary-value-param)
+		/// @brief The virtual method called to try to unblock an ability.
+		GDVIRTUAL1RC(int, _try_unblock, Variant); // NOLINT(*-unnecessary-value-param)
 
 		/// @brief Adds an ability to the container.
 		/// @param p_ability The ability to add.
@@ -261,23 +311,27 @@ namespace octod::gameplay::abilities
 		void set_initial_abilities(const TypedArray<Ability> &p_abilities);
 		/// @brief Activates an ability in the container.
 		/// @param p_ability_or_ability_name The ability to activate.
-		/// @return True if the ability was activated, false otherwise.
+		/// @return The resulting AbilityEventType.
 		[[nodiscard]] AbilityEventType try_activate(const Variant &p_ability_or_ability_name) const;
 		/// @brief Blocks an ability in the container.
 		/// @param p_ability_or_ability_name The ability to block.
-		/// @return True if the ability was blocked, false otherwise.
+		/// @return The resulting AbilityEventType.
 		[[nodiscard]] AbilityEventType try_block(const Variant &p_ability_or_ability_name) const;
 		/// @brief Ends an ability in the container.
 		/// @param p_ability_or_ability_name The ability to end.
-		/// @return True if the ability was ended, false otherwise.
+		/// @return The resulting AbilityEventType.
 		[[nodiscard]] AbilityEventType try_end(const Variant &p_ability_or_ability_name) const;
 		/// @brief Grants an ability to the container.
 		/// @param p_ability_or_ability_name The ability to grant.
 		[[nodiscard]] AbilityEventType try_grant(const Variant &p_ability_or_ability_name) const;
 		/// @brief Revokes an ability from the container.
 		/// @param p_ability_or_ability_name The ability to revoke.
-		/// @return True if the ability was revoked, false otherwise.
+		/// @return The resulting AbilityEventType.
 		[[nodiscard]] AbilityEventType try_revoke(const Variant &p_ability_or_ability_name) const;
+		/// @brief Unblocks an ability in the container.
+		/// @param p_ability_or_ability_name The ability to unblock.
+		/// @return The resulting AbilityEventType.
+		[[nodiscard]] AbilityEventType try_unblock(const Variant &p_ability_or_ability_name) const;
 	};
 
 #pragma endregion

--- a/src/ability_system.hpp
+++ b/src/ability_system.hpp
@@ -252,7 +252,7 @@ namespace octod::gameplay::abilities
 		void _on_cooldown_start(const Ref<RuntimeAbility> &p_runtime_ability);
 		/// @brief Handles the ability unblock signal.
 		/// @param p_runtime_ability The runtime ability.
-		void _on_unblocked(const Ref<RuntimeAbility> &p_runtime_ability);
+		void _on_unblocked_ability(const Ref<RuntimeAbility> &p_runtime_ability);
 
 	public:
 		/// @brief Returns an instance of a RuntimeAbility. Override this method if you want to use an extended class of RuntimeAbility.
@@ -392,6 +392,7 @@ namespace octod::gameplay::abilities
 		/// @param The ability container.
 		GDVIRTUAL2(_on_revoke, AbilityContainer *, RuntimeAbility *);
 		/// @brief Called when the ability is ticked.
+		/// @note If you override this method you will have to deal by hand with automatic blocking/unblocking, cooldown and duration etc.
 		/// @param The ability container.
 		GDVIRTUAL4(_on_tick, double, double, AbilityContainer *, RuntimeAbility *);
 		/// @brief Called when the ability container checks if the ability should be activated.
@@ -400,6 +401,10 @@ namespace octod::gameplay::abilities
 		GDVIRTUAL1RC(bool, _should_be_blocked, AbilityContainer *);
 		/// @brief Called when the ability container checks if the ability should be granted.
 		GDVIRTUAL1RC(bool, _should_be_ended, AbilityContainer *);
+		/// @brief Called when the ability container checks if the ability cooldown should be reset when blocked.
+		GDVIRTUAL1RC(bool, _should_reset_cooldown_on_block, AbilityContainer *);
+		/// @brief Called when the ability container checks if the ability duration should be reset when blocked.
+		GDVIRTUAL1RC(bool, _should_reset_duration_on_block, AbilityContainer *);
 
 		/// @brief Gets the ability name.
 		/// @return The ability name.

--- a/src/ability_system.hpp
+++ b/src/ability_system.hpp
@@ -20,6 +20,8 @@ namespace octod::gameplay::abilities
 	{
 		/// @brief Represents the ability being in no state.
 		ABILITY_STATE_IDLE = 1 << 0,
+		/// @brief Represents the ability being cooling down.
+		ABILITY_STATE_COOLING_DOWN = 1 << 1,
 		/// @brief Represents the ability being active.
 		ABILITY_STATE_ACTIVE = 1 << 2,
 		/// @brief Represents the ability being blocked.
@@ -71,6 +73,8 @@ namespace octod::gameplay::abilities
 		ABILITY_EVENT_TYPE_REFUSED_TO_END_IS_BLOCKED,
 		/// @brief Represents the ability being refused to end because it is not active.
 		ABILITY_EVENT_TYPE_REFUSED_TO_END_IS_NOT_ACTIVE,
+		/// @brief Represents the ability being refused to end because it is cooling down.
+		ABILITY_EVENT_TYPE_REFUSED_TO_END_IS_COOLING_DOWN,
 		/// @brief Represents the ability being refused to end because it is not granted.
 		ABILITY_EVENT_TYPE_REFUSED_TO_END_IS_NOT_GRANTED,
 

--- a/src/ability_system.hpp
+++ b/src/ability_system.hpp
@@ -33,6 +33,8 @@ namespace octod::gameplay::abilities
 		/// success events
 		/// @brief Represents the ability being activated.
 		ABILITY_EVENT_TYPE_ACTIVATED,
+		ABILITY_EVENT_TYPE_ACTIVATED_COOLDOWN_STARTED,
+		ABILITY_EVENT_TYPE_ACTIVATED_DURATION_STARTED,
 		/// @brief Represents the ability being blocked.
 		ABILITY_EVENT_TYPE_BLOCKED,
 		/// @brief Represents the ability being ended.
@@ -199,6 +201,12 @@ namespace octod::gameplay::abilities
 		/// @brief Handles the tick.
 		/// @param p_delta The delta time.
 		void handle_tick(double p_delta);
+
+		/// @brief Triggers the ability cooldown.
+		bool trigger_cooldown();
+
+		/// @brief Triggers the ability duration.
+		bool trigger_duration();
 	};
 
 #pragma endregion
@@ -281,7 +289,7 @@ namespace octod::gameplay::abilities
 		/// @brief Gets an ability.
 		/// @param p_variant The ability to get.
 		/// @return The ability.
-		[[nodiscard]] Ref<RuntimeAbility> get_ability(const Variant &p_variant) const;
+		[[nodiscard]] Ref<RuntimeAbility> get_runtime_ability(const Variant &p_variant) const;
 		/// @brief Checks if the container has an ability.
 		/// @param p_variant The ability to check.
 		/// @return True if the container has the ability, false otherwise.
@@ -294,6 +302,10 @@ namespace octod::gameplay::abilities
 		/// @param p_variant The ability to check.
 		/// @return True if the ability is blocked, false otherwise.
 		[[nodiscard]] bool is_ability_blocked(const Variant &p_variant) const;
+		/// @brief Checks if the ability cooldown is active.
+		/// @param p_variant The ability to check.
+		/// @return True if the ability cooldown is active, false otherwise.
+		[[nodiscard]] bool is_ability_cooldown_active(const Variant &p_variant) const;
 		/// @brief Checks if the ability is ended.
 		/// @param p_variant The ability to check.
 		/// @return True if the ability is ended, false otherwise.

--- a/src/ability_system.hpp
+++ b/src/ability_system.hpp
@@ -16,19 +16,19 @@ namespace octod::gameplay::abilities
 #pragma region RuntimeAbility
 
 	/// @brief Let's have fun with bitmasks to handle the ability internal state.
-	enum AbilityState : unsigned int
+	enum AbilityState : uint8_t
 	{
 		/// @brief Represents the ability being in no state.
 		ABILITY_STATE_IDLE = 1 << 0,
 		/// @brief Represents the ability being active.
-		ABILITY_STATE_ACTIVE = 1 << 1,
+		ABILITY_STATE_ACTIVE = 1 << 2,
 		/// @brief Represents the ability being blocked.
-		ABILITY_STATE_BLOCKED = 1 << 2,
+		ABILITY_STATE_BLOCKED = 1 << 4,
 		/// @brief Represents the ability being granted.
-		ABILITY_STATE_GRANTED = 1 << 3,
+		ABILITY_STATE_GRANTED = 1 << 6,
 	};
 
-	enum AbilityEventType : unsigned int
+	enum AbilityEventType : uint8_t
 	{
 		/// success events
 		/// @brief Represents the ability being activated.
@@ -74,7 +74,9 @@ namespace octod::gameplay::abilities
 		/// @brief Represents the ability being refused to end because it is not granted.
 		ABILITY_EVENT_TYPE_REFUSED_TO_END_IS_NOT_GRANTED,
 
-		/// @brief Represents the ability being refused to grant.
+		/// @brief Represents the ability
+		/// being refused
+		/// to be granted.
 		ABILITY_EVENT_TYPE_REFUSED_TO_GRANT,
 		/// @brief Represents the ability being refused to grant because it is already granted.
 		ABILITY_EVENT_TYPE_REFUSED_TO_GRANT_ALREADY_GRANTED,
@@ -113,80 +115,14 @@ namespace octod::gameplay::abilities
 	};
 
 	/// @brief Represents an ability that at runtime.
+	//reSharper disable once CppClassCanBeFinal
 	class RuntimeAbility : public RefCounted
 	{
 		GDCLASS(RuntimeAbility, RefCounted);
-
-		/// @brief Marks the ability state. Using a bitmask to store the state.
-		int state = ABILITY_STATE_IDLE;
-
-	public:
-		/// @brief Activates the ability.
-		AbilityEventType activate();
-		/// @brief Blocks the ability.
-		AbilityEventType block();
-		/// @brief Ends the ability.
-		AbilityEventType end();
-		/// @brief Gets the ability.
-		/// @return The ability.
-		[[nodiscard]] Ref<Ability> get_ability() const;
-		/// @brief Gets the ability container.
-		/// @return The ability container.
-		[[nodiscard]] AbilityContainer *get_container() const;
-		/// @brief Gets the ability cooldown.
-		/// @return The ability cooldown.
-		[[nodiscard]] double get_cooldown() const;
-		/// @brief Gets the ability duration.
-		/// @return The ability duration.
-		[[nodiscard]] double get_duration() const;
-		/// @brief Grants the ability.
-		AbilityEventType grant();
-		/// @brief Returns true if the ability is active.
-		/// @return True if the ability is active, false otherwise.
-		[[nodiscard]] bool is_active() const;
-		/// @brief Returns true if the ability is blocked.
-		/// @return True if the ability is blocked, false otherwise.
-		[[nodiscard]] bool is_blocked() const;
-		/// @brief Returns true if the ability is cooling down.
-		/// @return True if the ability is cooling down, false otherwise.
-		[[nodiscard]] bool is_cooldown_active() const;
-		/// @brief Returns true if the ability is duration active.
-		/// @return True if the ability is duration active, false otherwise.
-		[[nodiscard]] bool is_duration_active() const;
-		/// @brief Returns true if the ability is ended.
-		/// @return True if the ability is ended, false otherwise.
-		[[nodiscard]] bool is_ended() const;
-		/// @brief Returns true if the ability is granted.
-		/// @return True if the ability is granted, false otherwise.
-		[[nodiscard]] bool is_granted() const;
-		/// @brief Returns true if the ability is revoked.
-		/// @return True if the ability is revoked, false otherwise.
-		[[nodiscard]] bool is_revoked() const;
-		/// @brief Revokes the ability.
-		AbilityEventType revoke();
-		/// @brief Sets the ability.
-		/// @param p_ability The ability.
-		void set_ability(const Ref<Ability> &p_ability);
-		/// @brief Sets the ability container.
-		/// @param p_container The ability container.
-		void set_container(AbilityContainer *p_container);
-		/// @brief Returns true if the ability should be activated.
-		/// @return True if the ability should be activated, false otherwise.
-		[[nodiscard]] bool should_be_activated() const;
-		/// @brief Returns true if the ability should be blocked.
-		/// @return True if the ability should be blocked, false otherwise.
-		[[nodiscard]] bool should_be_blocked() const;
-		/// @brief Returns true if the ability should be ended.
-		/// @return True if the ability should be ended, false otherwise.
-		[[nodiscard]] bool should_be_ended() const;
-		/// @brief Unblocks the ability.
-		[[nodiscard]] AbilityEventType unblock();
-
-	protected:
-		friend class AbilityContainer;
-
-		/// @brief Binds the methods to godot.
-		static void _bind_methods();
+		/// @brief Marks the ability state.
+		/// Using a bitmask
+		/// to store the state.
+		uint8_t state = ABILITY_STATE_IDLE;
 		/// @brief The ability resource.
 		Ref<Ability> ability;
 		/// @brief The ability container which contains, owns and runs the ability.
@@ -197,6 +133,95 @@ namespace octod::gameplay::abilities
 		double duration_time = 0.0;
 		/// @brief The last tick time. Used by cooldown.
 		double cooldown_time = 0.0;
+
+	public:
+		/// @brief Activates the ability.
+		AbilityEventType activate();
+
+		/// @brief Blocks the ability.
+		AbilityEventType block();
+
+		/// @brief Ends the ability.
+		AbilityEventType end();
+
+		/// @brief Gets the ability.
+		/// @return The ability.
+		[[nodiscard]] Ref<Ability> get_ability() const;
+
+		/// @brief Gets the ability container.
+		/// @return The ability container.
+		[[nodiscard]] AbilityContainer *get_container() const;
+
+		/// @brief Gets the ability cooldown.
+		/// @return The ability cooldown.
+		[[nodiscard]] double get_cooldown() const;
+
+		/// @brief Gets the ability duration.
+		/// @return The ability duration.
+		[[nodiscard]] double get_duration() const;
+
+		/// @brief Grants the ability.
+		AbilityEventType grant();
+
+		/// @brief Returns true if the ability is active.
+		/// @return True if the ability is active, false otherwise.
+		[[nodiscard]] bool is_active() const;
+
+		/// @brief Returns true if the ability is blocked.
+		/// @return True if the ability is blocked, false otherwise.
+		[[nodiscard]] bool is_blocked() const;
+
+		/// @brief Returns true if the ability is cooling down.
+		/// @return True if the ability is cooling down, false otherwise.
+		[[nodiscard]] bool is_cooldown_active() const;
+
+		/// @brief Returns true if the ability is duration active.
+		/// @return True if the ability is duration active, false otherwise.
+		[[nodiscard]] bool is_duration_active() const;
+
+		/// @brief Returns true if the ability is ended.
+		/// @return True if the ability is ended, false otherwise.
+		[[nodiscard]] bool is_ended() const;
+
+		/// @brief Returns true if the ability is granted.
+		/// @return True if the ability is granted, false otherwise.
+		[[nodiscard]] bool is_granted() const;
+
+		/// @brief Returns true if the ability is revoked.
+		/// @return True if the ability is revoked, false otherwise.
+		[[nodiscard]] bool is_revoked() const;
+
+		/// @brief Revokes the ability.
+		AbilityEventType revoke();
+
+		/// @brief Sets the ability.
+		/// @param p_ability The ability.
+		void set_ability(const Ref<Ability> &p_ability);
+
+		/// @brief Sets the ability container.
+		/// @param p_container The ability container.
+		void set_container(AbilityContainer *p_container);
+
+		/// @brief Returns true if the ability should be activated.
+		/// @return True if the ability should be activated, false otherwise.
+		[[nodiscard]] bool should_be_activated() const;
+
+		/// @brief Returns true if the ability should be blocked.
+		/// @return True if the ability should be blocked, false otherwise.
+		[[nodiscard]] bool should_be_blocked() const;
+
+		/// @brief Returns true if the ability should be ended.
+		/// @return True if the ability should be ended, false otherwise.
+		[[nodiscard]] bool should_be_ended() const;
+
+		/// @brief Unblocks the ability.
+		[[nodiscard]] AbilityEventType unblock();
+
+	protected:
+		friend class AbilityContainer;
+
+		/// @brief Binds the methods to godot.
+		static void _bind_methods();
 
 		/// @brief Handles the tick.
 		/// @param p_delta The delta time.
@@ -219,43 +244,52 @@ namespace octod::gameplay::abilities
 #pragma region AbilityContainer
 
 	/// @brief Represents a container of abilities.
+	// ReSharper disable once CppClassCanBeFinal
 	class AbilityContainer : public Node
 	{
 		GDCLASS(AbilityContainer, Node)
+		/// @brief The runtime abilities.
+		Dictionary runtime_abilities = Dictionary();
+		TypedArray<Ability> initial_abilities = TypedArray<Ability>();
 
 	protected:
 		/// @brief Binds the methods to godot.
 		static void _bind_methods();
-		/// @brief The runtime abilities.
-		Dictionary runtime_abilities = Dictionary();
-		TypedArray<Ability> initial_abilities = TypedArray<Ability>();
 
 		[[nodiscard]] Ref<RuntimeAbility> build_runtime_ability(const Ref<Ability> &p_ability) const;
 
 		/// @brief Called when the node receives a notification.
 		// ReSharper disable once CppHidingFunction
 		void _notification(int p_what);
+
 		/// @brief Handles the active ability signal.
 		/// @param p_runtime_ability The runtime ability.
 		void _on_active_ability(const Ref<RuntimeAbility> &p_runtime_ability);
+
 		/// @brief Handles the blocked ability signal.
 		/// @param p_runtime_ability The runtime ability.
 		void _on_blocked_ability(const Ref<RuntimeAbility> &p_runtime_ability);
+
 		/// @brief Handles the ended ability signal.
 		/// @param p_runtime_ability The runtime ability.
 		void _on_ended_ability(const Ref<RuntimeAbility> &p_runtime_ability);
+
 		/// @brief Handles the granted ability signal.
 		/// @param p_runtime_ability The runtime ability.
 		void _on_granted_ability(const Ref<RuntimeAbility> &p_runtime_ability);
+
 		/// @brief Handles the revoked ability signal.
 		/// @param p_runtime_ability The runtime ability.
 		void _on_revoked_ability(const Ref<RuntimeAbility> &p_runtime_ability);
+
 		/// @brief Handles the cooldown end signal.
 		/// @param p_runtime_ability The runtime ability.
 		void _on_cooldown_end(const Ref<RuntimeAbility> &p_runtime_ability);
+
 		/// @brief Handles the cooldown start signal.
 		/// @param p_runtime_ability The runtime ability.
 		void _on_cooldown_start(const Ref<RuntimeAbility> &p_runtime_ability);
+
 		/// @brief Handles the ability unblock signal.
 		/// @param p_runtime_ability The runtime ability.
 		void _on_unblocked_ability(const Ref<RuntimeAbility> &p_runtime_ability);
@@ -282,70 +316,88 @@ namespace octod::gameplay::abilities
 		/// @param p_ability The ability to add.
 		/// @return True if the ability was added, false otherwise.
 		bool add_ability(const Ref<Ability> &p_ability);
+
 		/// @brief Finds an ability in the container by calling a predicate.
 		/// @param p_predicate The predicate to find the ability.
 		/// @return The ability
 		[[nodiscard]] Ref<RuntimeAbility> find_ability(const Callable &p_predicate) const;
+
 		/// @brief Gets the runtime abilities.
 		/// @return The runtime abilities.
-		[[nodiscard]] TypedArray<RuntimeAbility> get_abilities() const;
+		[[nodiscard]] TypedArray<RuntimeAbility> get_runtime_abilities() const;
+
 		/// @brief Gets the initial abilities.
 		/// @return The initial abilities.
 		[[nodiscard]] TypedArray<Ability> get_initial_abilities() const;
+
 		/// @brief Gets an ability.
 		/// @param p_variant The ability to get.
 		/// @return The ability.
 		[[nodiscard]] Ref<RuntimeAbility> get_runtime_ability(const Variant &p_variant) const;
+
 		/// @brief Checks if the container has an ability.
 		/// @param p_variant The ability to check.
 		/// @return True if the container has the ability, false otherwise.
 		[[nodiscard]] bool has_ability(const Variant &p_variant) const;
+
 		/// @brief Checks if the ability is active.
 		/// @param p_variant The ability to check.
 		/// @return True if the ability is active, false otherwise.
 		[[nodiscard]] bool is_ability_active(const Variant &p_variant) const;
+
 		/// @brief Checks if the ability is blocked.
 		/// @param p_variant The ability to check.
 		/// @return True if the ability is blocked, false otherwise.
 		[[nodiscard]] bool is_ability_blocked(const Variant &p_variant) const;
+
 		/// @brief Checks if the ability cooldown is active.
 		/// @param p_variant The ability to check.
 		/// @return True if the ability cooldown is active, false otherwise.
 		[[nodiscard]] bool is_ability_cooldown_active(const Variant &p_variant) const;
+
 		/// @brief Checks if the ability is ended.
 		/// @param p_variant The ability to check.
 		/// @return True if the ability is ended, false otherwise.
 		[[nodiscard]] bool is_ability_ended(const Variant &p_variant) const;
+
 		/// @brief Checks if the ability is granted.
 		/// @param p_variant The ability to check.
 		/// @return True if the ability is granted, false otherwise.
 		[[nodiscard]] bool is_ability_granted(const Variant &p_variant) const;
+
 		/// @brief Removes an ability from the container.
 		/// @param p_ability The ability to remove.
 		/// @return True if the ability was removed, false otherwise.
 		bool remove_ability(const Ref<Ability> &p_ability);
+
 		/// @brief Sets the abilities in the container.
 		/// @param p_abilities The abilities to set.
 		void set_initial_abilities(const TypedArray<Ability> &p_abilities);
+
 		/// @brief Activates an ability in the container.
 		/// @param p_ability_or_ability_name The ability to activate.
 		/// @return The resulting AbilityEventType.
 		[[nodiscard]] AbilityEventType try_activate(const Variant &p_ability_or_ability_name) const;
+
 		/// @brief Blocks an ability in the container.
 		/// @param p_ability_or_ability_name The ability to block.
 		/// @return The resulting AbilityEventType.
 		[[nodiscard]] AbilityEventType try_block(const Variant &p_ability_or_ability_name) const;
+
 		/// @brief Ends an ability in the container.
 		/// @param p_ability_or_ability_name The ability to end.
 		/// @return The resulting AbilityEventType.
 		[[nodiscard]] AbilityEventType try_end(const Variant &p_ability_or_ability_name) const;
+
 		/// @brief Grants an ability to the container.
 		/// @param p_ability_or_ability_name The ability to grant.
 		[[nodiscard]] AbilityEventType try_grant(const Variant &p_ability_or_ability_name) const;
+
 		/// @brief Revokes an ability from the container.
 		/// @param p_ability_or_ability_name The ability to revoke.
 		/// @return The resulting AbilityEventType.
 		[[nodiscard]] AbilityEventType try_revoke(const Variant &p_ability_or_ability_name) const;
+
 		/// @brief Unblocks an ability in the container.
 		/// @param p_ability_or_ability_name The ability to unblock.
 		/// @return The resulting AbilityEventType.
@@ -355,13 +407,10 @@ namespace octod::gameplay::abilities
 #pragma endregion
 #pragma region Ability
 
+	// ReSharper disable once CppClassCanBeFinal
 	class Ability : public Resource
 	{
 		GDCLASS(Ability, Resource)
-
-	protected:
-		/// @brief Binds the methods to godot.
-		static void _bind_methods();
 		/// @brief The ability name.
 		StringName ability_name;
 
@@ -372,7 +421,8 @@ namespace octod::gameplay::abilities
 		GDVIRTUAL2RC(bool, _can_be_activated, AbilityContainer *, RuntimeAbility *);
 		/// @brief Called when the ability container checks if the ability can be blocked.
 		GDVIRTUAL2RC(bool, _can_be_blocked, AbilityContainer *, RuntimeAbility *);
-		/// @brief Called when the ability container checks if the ability can be cancelled.
+		/// @brief Called when the ability container checks
+		///		   if the ability can be canceled.
 		GDVIRTUAL2RC(bool, _can_be_granted, AbilityContainer *, RuntimeAbility *);
 		/// @brief Called when the ability container checks if the ability can be ended.
 		GDVIRTUAL2RC(bool, _can_be_revoked, AbilityContainer *, RuntimeAbility *);
@@ -398,7 +448,11 @@ namespace octod::gameplay::abilities
 		/// @param The ability container.
 		GDVIRTUAL2(_on_revoke, AbilityContainer *, RuntimeAbility *);
 		/// @brief Called when the ability is ticked.
-		/// @note If you override this method you will have to deal by hand with automatic blocking/unblocking, cooldown and duration etc.
+		/// @note If you override this method,
+		///		  you will have
+		///		  to deal by hand with automatic blocking/unblocking,
+		///		  cooldown and duration,
+		///		  etc.
 		/// @param The ability container.
 		GDVIRTUAL4(_on_tick, double, double, AbilityContainer *, RuntimeAbility *);
 		/// @brief Called when the ability container checks if the ability should be activated.
@@ -415,9 +469,14 @@ namespace octod::gameplay::abilities
 		/// @brief Gets the ability name.
 		/// @return The ability name.
 		[[nodiscard]] StringName get_ability_name() const;
+
 		/// @brief Sets the ability name.
 		/// @param p_ability_name The ability name.
 		void set_ability_name(const StringName &p_ability_name);
+
+	protected:
+		/// @brief Binds the methods to godot.
+		static void _bind_methods();
 	};
 
 #pragma endregion


### PR DESCRIPTION
This pull request includes significant changes to the abilities system in the project, including updates to the ability states, event types, and the handling of abilities in the Godot engine. The most important changes are listed below:

### Abilities System Enhancements:

* [`src/ability_system.hpp`](diffhunk://#diff-3d4d34edcaf342863aef7270cfccb04d37a5186d274a8a84d66755d7bac7a2f9L19-L67): Updated `AbilityState` and `AbilityEventType` enums to use `uint8_t` instead of `unsigned int`, added new states and event types, and improved documentation for each state and event.
* Added new `AttributeContainer::try_unblock` method to try to unblock an ability
* Added new `RuntimeAbility::is_revoked` method to check if an ability is revoked.
* Added new `RuntimeAbility::unblock` method to unblock a blocked ability.

### Godot Integration:

* [`demo/examples/abilities_states/abilities_states.gd`](diffhunk://#diff-ed097c273aefc5767c21f0ff4d7115b4cfee9adc0871bcca5c3a9b726f4346f2R2-R68): Added new `@onready` variables for UI elements and connected signals to handle state changes. Implemented functions to manage ability states and UI updates.
* [`demo/examples/abilities_states/abilities_states.tscn`](diffhunk://#diff-7509658931f1162981f6feac1fe3bf07d11c620beb9b5090bdbf41eb154bd986R19-R122): Updated the scene to include new UI elements for managing abilities and their states, such as buttons and spin boxes for cooldown and duration.

### Code and Configuration Cleanup:

* [`.clang-format`](diffhunk://#diff-1026e0038b722990204a42bed8a6f7c0ec2302aa79e3fad1959d62ba968edfa2L87-R89): Commented out the `IndentBraces`, `IndentClasses`, and `IndentNamespaces` settings.
* [`godot-cpp`](diffhunk://#diff-442e6baf64aeb36da06077ebdd82f4e17d1a80fb2870456683a2ba19828f33c0L1-R1): Updated the submodule commit to the latest version.

These changes improve the functionality and usability of the abilities system, making it more robust and easier to manage within the Godot engine.

### Breaking changes

* `AttributeContainer::get_ability` have been renamed to `AttributeContainer::get_runtime_ability` 
* `AttributeContainer::get_abilities` have been renamed to  and `AttributeContainer::get_runtime_abilities`