### PR TITLE
Feat: adds new methods to get cooldown and duration times

### DIFF
--- a/doc_classes/RuntimeAbility.xml
+++ b/doc_classes/RuntimeAbility.xml
@@ -43,16 +43,16 @@
 				Gets the cooldown of the ability.
 			</description>
 		</method>
-		<method name="get_remaining_cooldown" qualifiers="const">
-			<return type="float" />
-			<description>
-				Gets the remaining cooldown of the ability.
-			</description>
-		</method>
 		<method name="get_duration" qualifiers="const">
 			<return type="float" />
 			<description>
 				Gets the duration of the ability.
+			</description>
+		</method>
+		<method name="get_remaining_cooldown" qualifiers="const">
+			<return type="float" />
+			<description>
+				Gets the remaining cooldown of the ability.
 			</description>
 		</method>
 		<method name="get_remaining_duration" qualifiers="const">

--- a/doc_classes/RuntimeAbility.xml
+++ b/doc_classes/RuntimeAbility.xml
@@ -43,10 +43,22 @@
 				Gets the cooldown of the ability.
 			</description>
 		</method>
+		<method name="get_remaining_cooldown" qualifiers="const">
+			<return type="float" />
+			<description>
+				Gets the remaining cooldown of the ability.
+			</description>
+		</method>
 		<method name="get_duration" qualifiers="const">
 			<return type="float" />
 			<description>
 				Gets the duration of the ability.
+			</description>
+		</method>
+		<method name="get_remaining_duration" qualifiers="const">
+			<return type="float" />
+			<description>
+				Gets the remaining duration of the ability.
 			</description>
 		</method>
 		<method name="grant">

--- a/src/ability_system.cpp
+++ b/src/ability_system.cpp
@@ -342,15 +342,6 @@ double RuntimeAbility::get_cooldown() const
 	return 0.0;
 }
 
-double RuntimeAbility::get_remaining_cooldown() const
-{
-	if (IS_STATE(ABILITY_STATE_COOLING_DOWN) && is_cooldown_active()) {
-		return cooldown_time;
-	}
-
-	return 0.0;
-}
-
 Variant RuntimeAbility::get_data() const
 {
 	return data;
@@ -362,6 +353,15 @@ double RuntimeAbility::get_duration() const
 		if (double duration = 0.0; GDVIRTUAL_CALL_PTR(ability, _get_duration, container, duration)) {
 			return duration;
 		}
+	}
+
+	return 0.0;
+}
+
+double RuntimeAbility::get_remaining_cooldown() const
+{
+	if (IS_STATE(ABILITY_STATE_COOLING_DOWN) && is_cooldown_active()) {
+		return cooldown_time;
 	}
 
 	return 0.0;

--- a/src/ability_system.cpp
+++ b/src/ability_system.cpp
@@ -342,6 +342,15 @@ double RuntimeAbility::get_cooldown() const
 	return 0.0;
 }
 
+double RuntimeAbility::get_remaining_cooldown() const
+{
+	if (IS_STATE(ABILITY_STATE_COOLING_DOWN) && is_cooldown_active()) {
+		return cooldown_time;
+	}
+
+	return 0.0;
+}
+
 Variant RuntimeAbility::get_data() const
 {
 	return data;
@@ -353,6 +362,15 @@ double RuntimeAbility::get_duration() const
 		if (double duration = 0.0; GDVIRTUAL_CALL_PTR(ability, _get_duration, container, duration)) {
 			return duration;
 		}
+	}
+
+	return 0.0;
+}
+
+double RuntimeAbility::get_remaining_duration() const
+{
+	if (IS_STATE(ABILITY_STATE_ACTIVE) && is_active()) {
+		return duration_time;
 	}
 
 	return 0.0;
@@ -502,8 +520,10 @@ void RuntimeAbility::_bind_methods()
 	ClassDB::bind_method(D_METHOD("get_ability"), &RuntimeAbility::get_ability);
 	ClassDB::bind_method(D_METHOD("get_container"), &RuntimeAbility::get_container);
 	ClassDB::bind_method(D_METHOD("get_cooldown"), &RuntimeAbility::get_cooldown);
+	ClassDB::bind_method(D_METHOD("get_remaining_cooldown"), &RuntimeAbility::get_remaining_cooldown);
 	ClassDB::bind_method(D_METHOD("get_data"), &RuntimeAbility::get_data);
 	ClassDB::bind_method(D_METHOD("get_duration"), &RuntimeAbility::get_duration);
+	ClassDB::bind_method(D_METHOD("get_remaining_duration"), &RuntimeAbility::get_remaining_duration);
 	ClassDB::bind_method(D_METHOD("grant"), &RuntimeAbility::grant);
 	ClassDB::bind_method(D_METHOD("is_active"), &RuntimeAbility::is_active);
 	ClassDB::bind_method(D_METHOD("is_blocked"), &RuntimeAbility::is_blocked);

--- a/src/ability_system.cpp
+++ b/src/ability_system.cpp
@@ -520,9 +520,9 @@ void RuntimeAbility::_bind_methods()
 	ClassDB::bind_method(D_METHOD("get_ability"), &RuntimeAbility::get_ability);
 	ClassDB::bind_method(D_METHOD("get_container"), &RuntimeAbility::get_container);
 	ClassDB::bind_method(D_METHOD("get_cooldown"), &RuntimeAbility::get_cooldown);
-	ClassDB::bind_method(D_METHOD("get_remaining_cooldown"), &RuntimeAbility::get_remaining_cooldown);
 	ClassDB::bind_method(D_METHOD("get_data"), &RuntimeAbility::get_data);
 	ClassDB::bind_method(D_METHOD("get_duration"), &RuntimeAbility::get_duration);
+	ClassDB::bind_method(D_METHOD("get_remaining_cooldown"), &RuntimeAbility::get_remaining_cooldown);
 	ClassDB::bind_method(D_METHOD("get_remaining_duration"), &RuntimeAbility::get_remaining_duration);
 	ClassDB::bind_method(D_METHOD("grant"), &RuntimeAbility::grant);
 	ClassDB::bind_method(D_METHOD("is_active"), &RuntimeAbility::is_active);

--- a/src/ability_system.hpp
+++ b/src/ability_system.hpp
@@ -172,6 +172,10 @@ namespace octod::gameplay::abilities
 		/// @return The ability cooldown.
 		[[nodiscard]] double get_cooldown() const;
 
+		/// @brief Gets the remaining cooldown.
+		/// @return The remaining cooldown if active, 0.0 otherwise.
+		[[nodiscard]] double get_remaining_cooldown() const;
+
 		/// @brief Gets the ability's data.
 		/// @return The ability's data
 		[[nodiscard]] Variant get_data() const;
@@ -179,6 +183,10 @@ namespace octod::gameplay::abilities
 		/// @brief Gets the ability duration.
 		/// @return The ability duration.
 		[[nodiscard]] double get_duration() const;
+
+		/// @brief Gets the remaining duration of the ability.
+		/// @return The remaining duration if active, 0.0 otherwise.
+		[[nodiscard]] double get_remaining_duration() const;
 
 		/// @brief Grants the ability.
 		AbilityEventType grant();

--- a/src/ability_system.hpp
+++ b/src/ability_system.hpp
@@ -172,10 +172,6 @@ namespace octod::gameplay::abilities
 		/// @return The ability cooldown.
 		[[nodiscard]] double get_cooldown() const;
 
-		/// @brief Gets the remaining cooldown.
-		/// @return The remaining cooldown if active, 0.0 otherwise.
-		[[nodiscard]] double get_remaining_cooldown() const;
-
 		/// @brief Gets the ability's data.
 		/// @return The ability's data
 		[[nodiscard]] Variant get_data() const;
@@ -183,6 +179,10 @@ namespace octod::gameplay::abilities
 		/// @brief Gets the ability duration.
 		/// @return The ability duration.
 		[[nodiscard]] double get_duration() const;
+
+		/// @brief Gets the remaining cooldown.
+		/// @return The remaining cooldown if active, 0.0 otherwise.
+		[[nodiscard]] double get_remaining_cooldown() const;
 
 		/// @brief Gets the remaining duration of the ability.
 		/// @return The remaining duration if active, 0.0 otherwise.


### PR DESCRIPTION
### Added 

- Introduced `RuntimeAbility.get_remaining_cooldown()` to get the remaining cooldown in seconds if cooling down
- Introduced `RuntimeAbility.get_remaining_duration()` get the remaining duration in seconds if activated

### Updated

- RuntimeAbility.xml updated with new methods